### PR TITLE
Manage  agents' initial position

### DIFF
--- a/unity-sample-environment/Assets/Scripts/SceneController.cs
+++ b/unity-sample-environment/Assets/Scripts/SceneController.cs
@@ -33,6 +33,7 @@ namespace MLPlayer {
 		float episodeStartTime = 0f;
 
 		public static ManualResetEvent received = new ManualResetEvent(false);
+		private Vector3 FirstLocation;
 
 		void OnMassage(string msg) {
 			agent.action.Set (msg);
@@ -53,11 +54,12 @@ namespace MLPlayer {
 			episodeStartTime = Time.time;
 
 			environment.OnReset ();
-			agent.transform.position = new Vector3 (0,0,0);
+			agent.transform.position = FirstLocation;
 			agent.StartEpisode ();
 		}
 
 		void Start () {
+			FirstLocation = agent.transform.position;
 			StartNewEpisode ();
 			ws = new WebSocketSharp.WebSocket (url);
 			Debug.Log("connecting... " + url);


### PR DESCRIPTION
Agents should be initialized at intended position (not zero). Especially in multi agent situation, each agent may be initialized at different position.
