### PR TITLE
fix for iOS AOT compiler.

### DIFF
--- a/unity-sample-environment/Assets/Scripts/AIClient.cs
+++ b/unity-sample-environment/Assets/Scripts/AIClient.cs
@@ -14,7 +14,7 @@ namespace MLPlayer
 		private Thread th;
 		private Mutex mutAgent;
 		private Mutex mutAi;
-		private MsgPack.CompiledPacker packer;
+		private MessageSerializer msgSerializer;
 		
 		public delegate void MassageCB(byte[] msg, Agent agent);
 		MassageCB messageCallBack;
@@ -26,7 +26,7 @@ namespace MLPlayer
 			agent = _agent;
 			mutAgent = new Mutex();
 			mutAi = new Mutex();
-			packer = new MsgPack.CompiledPacker();
+			msgSerializer = new MessageSerializer();
 			agentMessageQueue = new Queue<byte[]>();
 			aiMessageQueue = new Queue<byte[]>();
 			th = new Thread(new ThreadStart(ExecuteInForeground));
@@ -72,7 +72,7 @@ namespace MLPlayer
 		}
 
 		public void PushAgentState(State s) {
-			byte[] msg = packer.Pack(s);
+			byte[] msg = msgSerializer.Pack(s);
 			mutAgent.WaitOne();
 			agentMessageQueue.Enqueue(msg);
 			mutAgent.ReleaseMutex();

--- a/unity-sample-environment/Assets/Scripts/AIClientAsync.cs
+++ b/unity-sample-environment/Assets/Scripts/AIClientAsync.cs
@@ -14,7 +14,7 @@ namespace MLPlayer {
 		private Thread th;
 		private Mutex mutAgent;
 		private Mutex mutAi;
-		private MsgPack.CompiledPacker packer;
+		private MessageSerializer msgSerializer;
 		public delegate void OnMessageFunc();
 		OnMessageFunc onMessageFunc;
 		
@@ -22,7 +22,7 @@ namespace MLPlayer {
 			url = _url;
 			mutAgent = new Mutex();
 			mutAi = new Mutex();
-			packer = new MsgPack.CompiledPacker();
+			msgSerializer = new MessageSerializer();
 			agentMessageQueue = new Queue<byte[]>();
 			aiMessageQueue = new Queue<byte[]>();
 			th = new Thread(new ThreadStart(ExecuteInForeground));
@@ -61,7 +61,7 @@ namespace MLPlayer {
 		}
 		
 		public void PushAgentState(State s) {
-			byte[] msg = packer.Pack(s);
+			byte[] msg = msgSerializer.Pack(s);
 			mutAgent.WaitOne();
 			agentMessageQueue.Enqueue(msg);
 			mutAgent.ReleaseMutex();

--- a/unity-sample-environment/Assets/Scripts/MessageSerializer.cs
+++ b/unity-sample-environment/Assets/Scripts/MessageSerializer.cs
@@ -1,0 +1,24 @@
+﻿using MsgPack;
+
+namespace MLPlayer {
+	
+	/// <summary>
+	/// MsgPack wrapper.
+	/// </summary>
+	public class MessageSerializer {
+	  
+#if UNITY_IOS
+		ObjectPacker packer = new ObjectPacker();
+#else
+		CompiledPacker packer = new CompiledPacker();
+#endif
+		
+		public byte[] Pack(object o) {
+			return packer.Pack(o);
+		}
+		
+		public T Unpack<T>(byte[] buf) {
+			return packer.Unpack<T>(buf);
+		}
+	}
+}

--- a/unity-sample-environment/Assets/Scripts/MessageSerializer.cs.meta
+++ b/unity-sample-environment/Assets/Scripts/MessageSerializer.cs.meta
@@ -1,0 +1,12 @@
+fileFormatVersion: 2
+guid: f7833b4c48de545469a9458d99548b08
+timeCreated: 1461479197
+licenseType: Free
+MonoImporter:
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
MsgPack.CompiledPacker だと iOSの実行時にエラーが出るため、ObjectPacker を使えるようにしました。
SceneController.cs の `MsgPack.BoxingPacker packer = new MsgPack.BoxingPacker ();` も置き換えたいですが、動かなくなるため、まずはこちらから置き換えられるようにしてあります。
