### PR TITLE
Fix CherryPy version

### DIFF
--- a/python-agent/requirements.txt
+++ b/python-agent/requirements.txt
@@ -1,6 +1,6 @@
 chainer
 ws4py
-cherrypy==8.9.1
+cherrypy<9.0.0
 msgpack-python
 pillow
 argparse

--- a/python-agent/requirements.txt
+++ b/python-agent/requirements.txt
@@ -1,6 +1,6 @@
 chainer
 ws4py
-cherrypy
+cherrypy==8.9.1
 msgpack-python
 pillow
 argparse


### PR DESCRIPTION
CherryPy 9.0.0以上はws4pyをサポートしていないため。9.0.0に満たないバージョンをインストールする必要があります